### PR TITLE
Update upcoming events to use type instead of tags.

### DIFF
--- a/src/main/java/com/animedetour/android/database/DataModule.java
+++ b/src/main/java/com/animedetour/android/database/DataModule.java
@@ -13,6 +13,7 @@ import com.animedetour.android.database.event.EventRepository;
 import com.animedetour.android.database.event.AllEventsByDayFactory;
 import com.animedetour.android.database.event.AllEventsWorker;
 import com.animedetour.android.database.event.FetchedEventMetrics;
+import com.animedetour.android.database.event.UpcomingEventByTypeFactory;
 import com.animedetour.android.database.event.UpcomingEventsByTagFactory;
 import com.animedetour.android.database.favorite.FavoriteRepository;
 import com.animedetour.android.database.favorite.GetAllFavoritesWorker;
@@ -58,7 +59,8 @@ final public class DataModule
                 local,
                 new AllEventsWorker(local, remote, metrics),
                 new AllEventsByDayFactory(local, remote, metrics),
-                new UpcomingEventsByTagFactory(local, remote, metrics)
+                new UpcomingEventsByTagFactory(local, remote, metrics),
+                new UpcomingEventByTypeFactory(local, remote, metrics)
             );
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/animedetour/android/database/event/EventRepository.java
+++ b/src/main/java/com/animedetour/android/database/event/EventRepository.java
@@ -47,25 +47,31 @@ public class EventRepository
     /** Worker for looking up a single event with a tag. */
     final private CriteriaWorkerFactory<Event, TagCriteria> upcomingByTagFactory;
 
+    /** Worker for looking up a single event of a type. */
+    final private CriteriaWorkerFactory<Event, TypeCriteria> upcomingByTypeFactory;
+
     /**
      * @param subscriptionFactory Manage in-flight requests to async repos.
      * @param localAccess A local DAO for storing events.
      * @param allEventsWorker Worker for looking up a list of all events.
      * @param allByDayFactory Worker for looking up a list of events by their start time.
      * @param upcomingByTagFactory Worker for looking up a single event with a tag.
+     * @param upcomingByTypeFactory Worker for looking up a single event of a type.
      */
     public EventRepository(
         SubscriptionFactory<Event> subscriptionFactory,
         Dao<Event, String> localAccess,
         AllEventsWorker allEventsWorker,
         CriteriaWorkerFactory<List<Event>, DateTime> allByDayFactory,
-        CriteriaWorkerFactory<Event, TagCriteria> upcomingByTagFactory
+        CriteriaWorkerFactory<Event, TagCriteria> upcomingByTagFactory,
+        CriteriaWorkerFactory<Event, TypeCriteria> upcomingByTypeFactory
     ) {
         this.localAccess = localAccess;
         this.allEventsWorker = allEventsWorker;
         this.subscriptionFactory = subscriptionFactory;
         this.allByDayFactory = allByDayFactory;
         this.upcomingByTagFactory = upcomingByTagFactory;
+        this.upcomingByTypeFactory = upcomingByTypeFactory;
     }
 
     /**
@@ -105,15 +111,28 @@ public class EventRepository
      */
     public Subscription findFeatured(Observer<Event> observer, long ordinal)
     {
-        return this.findUpcomingByTag(
-            "detour sponsored event",
+        return this.findUpcomingByType(
+            "Anime Detour Panel",
             ordinal,
             observer
         );
     }
 
     /**
-     * Finds all of the events containing a specific tag.
+     * Finds a single event of a given type.
+     */
+    public Subscription findUpcomingByType(String type, long ordinal, Observer<Event> observer)
+    {
+        String key = "findUpcomingByType:" + type + ":" + ordinal;
+        return this.subscriptionFactory.createSubscription(
+            this.upcomingByTypeFactory.createWorker(new TypeCriteria(type, ordinal)),
+            observer,
+            key
+        );
+    }
+
+    /**
+     * Finds a single event containing a specific tag.
      *
      * @param tag The tag to search for events containing.
      */

--- a/src/main/java/com/animedetour/android/database/event/TypeCriteria.java
+++ b/src/main/java/com/animedetour/android/database/event/TypeCriteria.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2015 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.database.event;
+
+/**
+ * Criteria for looking up a single event by tag.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+public class TypeCriteria
+{
+    /**
+     * The type to search for events containing.
+     */
+    final private String type;
+
+    /**
+     * The offset of the event to find in the list of events.
+     */
+    final private long ordinal;
+
+    /**
+     * @param type type to search for events containing.
+     * @param ordinal offset of the event to find in the list of events.
+     */
+    public TypeCriteria(String type, long ordinal)
+    {
+        this.ordinal = ordinal;
+        this.type = type;
+    }
+
+    /**
+     * @return The type to search for events containing.
+     */
+    final public String getType()
+    {
+        return type;
+    }
+
+    /**
+     * @return The offset of the event to find in the list of events.
+     */
+    final public long getOrdinal()
+    {
+        return ordinal;
+    }
+}

--- a/src/main/java/com/animedetour/android/database/event/UpcomingEventByTypeFactory.java
+++ b/src/main/java/com/animedetour/android/database/event/UpcomingEventByTypeFactory.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2015 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.database.event;
+
+import com.animedetour.api.sched.api.ScheduleEndpoint;
+import com.animedetour.api.sched.api.model.Event;
+import com.inkapplications.groundcontrol.CriteriaWorkerFactory;
+import com.inkapplications.groundcontrol.Worker;
+import com.j256.ormlite.dao.Dao;
+
+/**
+ * Creates new workers to lookup events by type so that we can pass criteria to it.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+final public class UpcomingEventByTypeFactory implements CriteriaWorkerFactory<Event, TypeCriteria>
+{
+    final private Dao<Event, String> localAccess;
+    final private ScheduleEndpoint remoteAccess;
+    final private FetchedEventMetrics fetchedMetrics;
+
+    public UpcomingEventByTypeFactory(
+        Dao<Event, String> localAccess,
+        ScheduleEndpoint remoteAccess,
+        FetchedEventMetrics fetchedMetrics
+    ) {
+        this.localAccess = localAccess;
+        this.remoteAccess = remoteAccess;
+        this.fetchedMetrics = fetchedMetrics;
+    }
+
+    @Override
+    public Worker<Event> createWorker(TypeCriteria criteria)
+    {
+        return new UpcomingEventByTypeWorker(
+            this.localAccess,
+            this.remoteAccess,
+            this.fetchedMetrics,
+            criteria
+        );
+    }
+}

--- a/src/main/java/com/animedetour/android/database/event/UpcomingEventByTypeWorker.java
+++ b/src/main/java/com/animedetour/android/database/event/UpcomingEventByTypeWorker.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2015 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.database.event;
+
+import com.animedetour.api.sched.api.ScheduleEndpoint;
+import com.animedetour.api.sched.api.model.Event;
+import com.inkapplications.groundcontrol.Worker;
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.stmt.PreparedQuery;
+import com.j256.ormlite.stmt.QueryBuilder;
+import com.j256.ormlite.stmt.Where;
+import org.joda.time.DateTime;
+import rx.Subscriber;
+
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Looks up a single event of a specified type after synchronizing with
+ * the remote API.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+public class UpcomingEventByTypeWorker implements Worker<Event>
+{
+    final private Dao<Event, String> localAccess;
+    final private ScheduleEndpoint remoteAccess;
+    final private FetchedEventMetrics fetchedEventMetrics;
+    final private TypeCriteria criteria;
+
+    public UpcomingEventByTypeWorker(
+        Dao<Event, String> localAccess,
+        ScheduleEndpoint remoteAccess,
+        FetchedEventMetrics fetchedEventMetrics,
+        TypeCriteria type
+    ) {
+        this.localAccess = localAccess;
+        this.remoteAccess = remoteAccess;
+        this.fetchedEventMetrics = fetchedEventMetrics;
+        this.criteria = type;
+    }
+
+    @Override
+    public void call(Subscriber<? super Event> subscriber)
+    {
+        try {
+            Event currentEvents = this.lookupLocal();
+            subscriber.onNext(currentEvents);
+
+            if (false == this.fetchedEventMetrics.dataIsStale()) {
+                return;
+            }
+
+            Event mostRecent = this.fetchedEventMetrics.getMostRecentUpdated();
+            long since = mostRecent == null ? 0 : mostRecent.getFetched().getMillis();
+
+            List<Event> events = this.remoteAccess.getSchedule(since);
+            this.saveLocal(events);
+
+            Event newEvent = this.lookupLocal();
+            subscriber.onNext(newEvent);
+        } catch (Exception e) {
+            subscriber.onError(e);
+        }
+    }
+
+    /**
+     * Get an upcoming event by type and position.
+     *
+     * Searches for events of a specified type, orders them by their
+     * start time excluding events that have already started, and returns a
+     * single event of the specified position.
+     *
+     * @return The upcoming event
+     */
+    @Override
+    public Event lookupLocal() throws SQLException
+    {
+        QueryBuilder<Event, String> builder = this.localAccess.queryBuilder();
+        Where<Event, String> where = builder.where();
+        where.eq("eventType", this.criteria.getType());
+        where.and();
+        where.gt("start", new DateTime());
+        builder.orderBy("start", true);
+        builder.offset(this.criteria.getOrdinal() - 1);
+        builder.limit(1L);
+        PreparedQuery<Event> prepared = builder.prepare();
+
+        Event result = this.localAccess.queryForFirst(prepared);
+
+        return result;
+    }
+
+    public void saveLocal(List<Event> events) throws SQLException
+    {
+        for (Event event : events) {
+            this.localAccess.createOrUpdate(event);
+        }
+    }
+}

--- a/src/main/java/com/animedetour/android/settings/DeveloperShims.java
+++ b/src/main/java/com/animedetour/android/settings/DeveloperShims.java
@@ -56,7 +56,7 @@ public class DeveloperShims
         Event event = new Event();
         event.setId("fake-event-" + this.random.nextInt());
         event.setName("Fake Upcoming Event");
-        event.setTags("detour sponsored event");
+        event.setTags("Anime Detour Panel");
         event.setDescription("A fake event generated from the developer settings!");
         event.setStartDateTime(new DateTime().plusMinutes(16));
         event.setEndDateTime(new DateTime().plusMinutes(17));


### PR DESCRIPTION
Official events are now of type `Anime Detour Panel` instead of tags. Updated code to reflect the change.