### PR TITLE
Add logic to remove events that have been removed remotely.

### DIFF
--- a/src/main/java/com/animedetour/api/sched/api/ScheduleEndpoint.java
+++ b/src/main/java/com/animedetour/api/sched/api/ScheduleEndpoint.java
@@ -25,4 +25,7 @@ public interface ScheduleEndpoint
 
     @GET("/sched_events")
     public List<Event> getSchedule(@Query("since") long sinceTimeStamp);
+
+    @GET("/sched_events")
+    public List<Event> getSchedule(@Query("since") long sinceTimeStamp, @Query("status") String status);
 }

--- a/src/main/java/com/inkapplications/groundcontrol/CriteriaWorkerFactory.java
+++ b/src/main/java/com/inkapplications/groundcontrol/CriteriaWorkerFactory.java
@@ -20,5 +20,11 @@ package com.inkapplications.groundcontrol;
  */
 public interface CriteriaWorkerFactory<YIELD, CRITERIA>
 {
+    /**
+     * Create a new worker.
+     *
+     * @param criteria The lookup criteria to be provided to the worker constructor.
+     * @return The fully constructed worker to use for data lookup.
+     */
     public Worker<YIELD> createWorker(CRITERIA criteria);
 }

--- a/src/main/java/com/inkapplications/groundcontrol/RemovableSyncWorker.java
+++ b/src/main/java/com/inkapplications/groundcontrol/RemovableSyncWorker.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015 Ink Applications, LLC.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+package com.inkapplications.groundcontrol;
+
+import java.sql.SQLException;
+
+/**
+ * A remote synchronized worker that provides an API for updated removed entities.
+ *
+ * @param <YIELD> The type of data that the worker will lookup and return.
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+abstract public class RemovableSyncWorker<YIELD> extends SyncWorker<YIELD>
+{
+    @Override
+    protected void syncRemote() throws Exception
+    {
+        super.syncRemote();
+
+        YIELD removed = this.lookupRemovedRemote();
+        this.removeLocal(removed);
+    }
+
+    /**
+     * Lookup the entities to be removed locally.
+     *
+     * @return Any entities that have been removed on the remote API.
+     * @throws Exception catch-all for if anything goes wrong in the lookup. Not
+     *                   considered fatal.
+     */
+    abstract public YIELD lookupRemovedRemote() throws Exception;
+
+    /**
+     * Remove local entities.
+     *
+     * Invoked to synchronize any entities that have been removed from the API
+     * and should therefore be removed locally as well.
+     *
+     * @param yield The entity or entities to remove.
+     * @throws SQLException If an error occurs when removing the entities from
+     *                      the local database.
+     */
+    abstract public void removeLocal(YIELD yield) throws SQLException;
+}

--- a/src/main/java/com/inkapplications/groundcontrol/SingleYieldWorker.java
+++ b/src/main/java/com/inkapplications/groundcontrol/SingleYieldWorker.java
@@ -19,7 +19,7 @@ import rx.Subscriber;
 abstract public class SingleYieldWorker<YIELD> implements Worker<YIELD>
 {
     @Override
-    public void call(Subscriber<? super YIELD> subscriber)
+    final public void call(Subscriber<? super YIELD> subscriber)
     {
         try {
             YIELD yield = this.lookupLocal();


### PR DESCRIPTION
Created a sync worker with an API for looking up remote entities that
have been removed so that they may be removed locally as well.

Since the remote entities are only saved as new events, a new api
was needed to fetch the event ID's that have been removed and delete
our local copies of them.