### PR TITLE
Notification Fixes

### DIFF
--- a/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ApplicationModule.java
+++ b/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ApplicationModule.java
@@ -19,7 +19,6 @@ import com.android.volley.toolbox.Volley;
 import com.animedetour.android.BuildConfig;
 import com.animedetour.android.R;
 import com.animedetour.android.database.DataModule;
-import com.animedetour.android.schedule.notification.EventNotificationManager;
 import com.animedetour.android.schedule.notification.NotificationScheduler;
 import com.animedetour.android.volley.cache.LongImageCache;
 import com.animedetour.api.ApiModule;
@@ -58,6 +57,11 @@ final public class ApplicationModule
         return this.application;
     }
 
+    @Provides @Singleton Context provideAppContext()
+    {
+        return this.application;
+    }
+
     @Provides @Singleton ImageLoader provideImageLoader(Application context)
     {
         RequestQueue queue = Volley.newRequestQueue(context);
@@ -76,13 +80,10 @@ final public class ApplicationModule
         return tracker;
     }
 
-    @Provides @Singleton EventNotificationManager provideNotificationManager(
+    @Provides @Singleton AlarmManager provideAlarmManager(
         Application context
     ) {
-        return new EventNotificationManager(
-            (AlarmManager) context.getSystemService(Context.ALARM_SERVICE),
-            context
-        );
+        return (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
     }
 
     @Provides @Singleton SubscriptionManager provideSubscriptionManager()

--- a/src/main/java/com/animedetour/android/schedule/notification/EventNotificationManager.java
+++ b/src/main/java/com/animedetour/android/schedule/notification/EventNotificationManager.java
@@ -13,21 +13,32 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import com.animedetour.android.settings.PreferenceManager;
 import com.animedetour.api.sched.api.model.Event;
 import org.joda.time.DateTime;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Schedules a notification alarm for the start-time of an event.
  *
  * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
  */
+@Singleton
 public class EventNotificationManager
 {
+    final private PreferenceManager preferenceManager;
     final private AlarmManager alarmManager;
     final private Context context;
 
-    public EventNotificationManager(AlarmManager alarmManager, Context context)
-    {
+    @Inject
+    public EventNotificationManager(
+        PreferenceManager preferenceManager,
+        AlarmManager alarmManager,
+        Context context
+    ) {
+        this.preferenceManager = preferenceManager;
         this.alarmManager = alarmManager;
         this.context = context;
     }
@@ -35,10 +46,17 @@ public class EventNotificationManager
     /**
      * Schedules an alarm 15 minutes before the specified event.
      *
+     * This will NOT schedule an alarm if the user has the notification
+     * preference turned off.
+     *
      * @param event The event to schedule an alarm for.
      */
     public void scheduleNotification(Event event)
     {
+        if (false == this.preferenceManager.receiveEventNotifications()) {
+            return;
+        }
+
         DateTime notificationTime = event.getStartDateTime().minusMinutes(15);
         if (notificationTime.isBeforeNow()) {
             return;

--- a/src/main/java/com/animedetour/android/schedule/notification/EventNotificationManager.java
+++ b/src/main/java/com/animedetour/android/schedule/notification/EventNotificationManager.java
@@ -13,32 +13,42 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import com.animedetour.android.database.favorite.FavoriteRepository;
+import com.animedetour.android.schedule.favorite.Favorite;
 import com.animedetour.android.settings.PreferenceManager;
 import com.animedetour.api.sched.api.model.Event;
+import org.apache.commons.logging.Log;
 import org.joda.time.DateTime;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.sql.SQLException;
 
 /**
- * Schedules a notification alarm for the start-time of an event.
+ * Schedules or cancels notifications alarm for the start-time of an event.
  *
  * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
  */
 @Singleton
 public class EventNotificationManager
 {
+    final private Log logger;
     final private PreferenceManager preferenceManager;
+    final private FavoriteRepository favoriteData;
     final private AlarmManager alarmManager;
     final private Context context;
 
     @Inject
     public EventNotificationManager(
+        Log logger,
         PreferenceManager preferenceManager,
+        FavoriteRepository favoriteData,
         AlarmManager alarmManager,
         Context context
     ) {
+        this.logger = logger;
         this.preferenceManager = preferenceManager;
+        this.favoriteData = favoriteData;
         this.alarmManager = alarmManager;
         this.context = context;
     }
@@ -62,6 +72,73 @@ public class EventNotificationManager
             return;
         }
 
+        this.logger.trace("Scheduling event notification: " + event);
+        PendingIntent intent = this.getEventIntent(event);
+        this.alarmManager.set(AlarmManager.RTC, notificationTime.getMillis(), intent);
+    }
+
+    /**
+     * Schedules or cancels all of the users favorite event notifications.
+     *
+     * @param enableNotifications whether the notifications should be enabled.
+     */
+    public void toggleNotifications(boolean enableNotifications)
+    {
+        if (enableNotifications) {
+            this.scheduleAllNotifications();
+        } else {
+            this.cancelAllNotifications();
+        }
+    }
+
+    /**
+     * Cancels all notifications for each of the users favorited events.
+     */
+    public void cancelAllNotifications()
+    {
+        try {
+            for (Favorite favorite : this.favoriteData.getAll()) {
+                this.cancelNotification(favorite.getEvent());
+            }
+        } catch (SQLException e) {
+            this.logger.error("Could not look up events to schedule notifications.", e);
+        }
+    }
+
+    /**
+     * Schedules a notification for each of the users favorited events.
+     */
+    public void scheduleAllNotifications()
+    {
+        try {
+            for (Favorite favorite : this.favoriteData.getAll()) {
+                this.scheduleNotification(favorite.getEvent());
+            }
+        } catch (SQLException e) {
+            this.logger.error("Could not look up events to schedule notifications.", e);
+        }
+    }
+
+    /**
+     * Cancels a pending notification.
+     *
+     * @param event The event to find the notification for - to be canceled.
+     */
+    public void cancelNotification(Event event)
+    {
+        this.logger.trace("Cancelling event notification: " + event);
+        PendingIntent intent = this.getEventIntent(event);
+        this.alarmManager.cancel(intent);
+    }
+
+    /**
+     * Create a notification intent for scheduling or cancelling.
+     *
+     * @param event The event that the notification is for.
+     * @return An intent that may be used to schedule or cancel a notification.
+     */
+    protected PendingIntent getEventIntent(Event event)
+    {
         Intent alarmIntent = new Intent(this.context, UpcomingEventReciever.class);
         Bundle bundle = new Bundle();
         bundle.putSerializable(UpcomingEventReciever.EXTRA_EVENT, event);
@@ -73,6 +150,6 @@ public class EventNotificationManager
             PendingIntent.FLAG_CANCEL_CURRENT
         );
 
-        alarmManager.set(AlarmManager.RTC, notificationTime.getMillis(), pendingIntent);
+        return pendingIntent;
     }
 }

--- a/src/main/java/com/animedetour/android/schedule/notification/NotificationScheduler.java
+++ b/src/main/java/com/animedetour/android/schedule/notification/NotificationScheduler.java
@@ -11,15 +11,11 @@ package com.animedetour.android.schedule.notification;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import com.animedetour.android.database.favorite.FavoriteRepository;
 import com.animedetour.android.framework.Application;
-import com.animedetour.android.schedule.favorite.Favorite;
-import com.animedetour.android.settings.PreferenceManager;
 import org.apache.commons.logging.Log;
 import prism.framework.PrismKernel;
 
 import javax.inject.Inject;
-import java.sql.SQLException;
 
 /**
  * Schedules all of the user's favorited events when the device boots.
@@ -32,13 +28,7 @@ import java.sql.SQLException;
 public class NotificationScheduler extends BroadcastReceiver
 {
     @Inject
-    FavoriteRepository favoriteData;
-
-    @Inject
     EventNotificationManager notificationManager;
-
-    @Inject
-    PreferenceManager preferences;
 
     @Inject
     Log logger;
@@ -50,16 +40,6 @@ public class NotificationScheduler extends BroadcastReceiver
         PrismKernel prismKernel = new PrismKernel(application);
         prismKernel.bootstrap(this);
 
-        if (false == this.preferences.receiveEventNotifications()) {
-            return;
-        }
-
-        try {
-            for (Favorite favorite : this.favoriteData.getAll()) {
-                this.notificationManager.scheduleNotification(favorite.getEvent());
-            }
-        } catch (SQLException e) {
-            this.logger.error("Could not look up events to schedule notifications.", e);
-        }
+        this.notificationManager.scheduleAllNotifications();
     }
 }

--- a/src/main/java/com/animedetour/android/settings/SettingsFragment.java
+++ b/src/main/java/com/animedetour/android/settings/SettingsFragment.java
@@ -23,6 +23,7 @@ import butterknife.OnLongClick;
 import com.animedetour.android.BuildConfig;
 import com.animedetour.android.R;
 import com.animedetour.android.framework.Fragment;
+import com.animedetour.android.schedule.notification.EventNotificationManager;
 
 import javax.inject.Inject;
 
@@ -59,6 +60,9 @@ final public class SettingsFragment extends Fragment
     PreferenceManager preferences;
 
     @Inject
+    EventNotificationManager notificationManager;
+
+    @Inject
     DeveloperShims developerShims;
 
     @Override
@@ -92,6 +96,7 @@ final public class SettingsFragment extends Fragment
     public void toggleNotifications(boolean checked)
     {
         this.preferences.setEventNotifications(checked);
+        this.notificationManager.toggleNotifications(checked);
     }
 
     /**


### PR DESCRIPTION
Prevent notifications from being scheduled when notifications are off
Changed the notification manager to check the preference anytime an
event is scheduled to prevent notifications from ever being scheduled
if the user has the preference turned off.

Cancel notifications when user preference is disabled.
Fixes an issue with the notifications still appearing if the user
disables the preference, since the previously scheduled notifications
wouldn't have been cancelled.