### PR TITLE
Fix incorrect image loading.

### DIFF
--- a/src/main/java/com/animedetour/android/guest/GuestIndexBinder.java
+++ b/src/main/java/com/animedetour/android/guest/GuestIndexBinder.java
@@ -53,11 +53,12 @@ public class GuestIndexBinder implements ItemViewBinder<GuestWidgetView, Guest>
     @Override
     public void bindView(Guest guest, GuestWidgetView view)
     {
-        view.setName(guest.getFullName());
         view.showDefaultImage();
+        view.bindGuest(guest);
+
         this.imageLoader.get(
             guest.getPhoto(),
-            new GuestWidgetImageLoader(view, this.log)
+            new GuestWidgetImageLoader(view, guest.getPhoto(), this.log)
         );
 
         GuestWidgetController controller = this.controllerFactory.create(guest);

--- a/src/main/java/com/animedetour/android/guest/GuestWidgetView.java
+++ b/src/main/java/com/animedetour/android/guest/GuestWidgetView.java
@@ -16,6 +16,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 import com.animedetour.android.R;
+import com.animedetour.api.guest.model.Guest;
 
 /**
  * A small widget view to represent a guest.
@@ -36,6 +37,8 @@ public class GuestWidgetView extends FrameLayout
      */
     final private TextView name;
 
+    private Guest displayedGuest;
+
     public GuestWidgetView(Context context)
     {
         this(context, null, 0);
@@ -53,6 +56,26 @@ public class GuestWidgetView extends FrameLayout
         LayoutInflater.from(context).inflate(R.layout.guest_widget_view, this);
         this.image = (ImageView) this.findViewById(R.id.guest_widget_image);
         this.name = (TextView) this.findViewById(R.id.guest_widget_name);
+    }
+
+    /**
+     * Attach a guest to the view for later reference and bind it's properties
+     * to the display.
+     *
+     * @param guest The guest to display in the view.
+     */
+    public void bindGuest(Guest guest)
+    {
+        this.setName(guest.getFirstName());
+        this.displayedGuest = guest;
+    }
+
+    /**
+     * @return The guest that is currently displayed in the view.
+     */
+    public Guest getDisplayedGuest()
+    {
+        return displayedGuest;
     }
 
     /**


### PR DESCRIPTION
Recycled views were causing an issue on the guest list with async
image loads. Since the listeners keep a reference to the views, but
the views get recycled, the callbacks would occasionally put the
image in the wrong view.
Fixed this issue by keeping a reference to the URL, which is just
a workaround for now until there is more time to refactor this.