### PR TITLE
Update modules to use Prism global services.

### DIFF
--- a/src/main/java/com/animedetour/android/framework/Application.java
+++ b/src/main/java/com/animedetour/android/framework/Application.java
@@ -68,14 +68,16 @@ final public class Application extends android.app.Application implements GraphC
     public Object[] getActivityModules(Activity activity)
     {
         return new Object[] {
-            new ActivityModule(activity),
+            new prism.module.ActivityModule(activity),
+            new ActivityModule(),
         };
     }
 
     private Object[] getApplicationModules()
     {
         return new Object[] {
-            new ApplicationModule(this),
+            new prism.module.ApplicationModule(this),
+            new ApplicationModule(),
         };
     }
 

--- a/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ActivityModule.java
+++ b/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ActivityModule.java
@@ -8,7 +8,6 @@
  */
 package com.animedetour.android.framework.dependencyinjection.module;
 
-import android.app.Activity;
 import com.animedetour.android.guest.GuestDetailActivity;
 import com.animedetour.android.guest.GuestIndexFragment;
 import com.animedetour.android.home.HomeFragment;
@@ -21,9 +20,6 @@ import com.animedetour.android.schedule.favorite.FavoritesFragment;
 import com.animedetour.android.schedule.ScheduleFragment;
 import com.animedetour.android.settings.SettingsFragment;
 import dagger.Module;
-import dagger.Provides;
-
-import javax.inject.Singleton;
 
 @Module(
     includes = {
@@ -47,15 +43,4 @@ import javax.inject.Singleton;
 )
 final public class ActivityModule
 {
-    final private Activity activity;
-
-    public ActivityModule(Activity activity)
-    {
-        this.activity = activity;
-    }
-
-    @Provides @Singleton Activity provideActivity()
-    {
-        return activity;
-    }
 }

--- a/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ApplicationModule.java
+++ b/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ApplicationModule.java
@@ -11,8 +11,6 @@ package com.animedetour.android.framework.dependencyinjection.module;
 import android.app.AlarmManager;
 import android.app.Application;
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.content.res.Resources;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.ImageLoader;
 import com.android.volley.toolbox.Volley;
@@ -49,23 +47,6 @@ import javax.inject.Singleton;
 )
 final public class ApplicationModule
 {
-    private android.app.Application application;
-
-    public ApplicationModule(android.app.Application application)
-    {
-        this.application = application;
-    }
-
-    @Provides @Singleton android.app.Application getApplication()
-    {
-        return this.application;
-    }
-
-    @Provides @Singleton Context provideAppContext()
-    {
-        return this.application;
-    }
-
     @Provides @Singleton ImageLoader provideImageLoader(
         Application context,
         OkHttpClient client
@@ -95,16 +76,5 @@ final public class ApplicationModule
     @Provides @Singleton SubscriptionManager provideSubscriptionManager()
     {
         return new SubscriptionManager();
-    }
-
-    @Provides @Singleton SharedPreferences provideSharedPreferences(
-        android.app.Application context
-    ) {
-        return context.getSharedPreferences("anime_detour", Context.MODE_PRIVATE);
-    }
-
-    @Provides @Singleton Resources provideResources(Application context)
-    {
-        return context.getResources();
     }
 }


### PR DESCRIPTION
The new version of prism has most of the android services defined
in a separate module. That module has been added and the self-defined
ones removed.

--------------------------------------------------------------------------------
BC break in shared preference storage, which will reset old preferences.

Q             | A
--------------|-------
Bug fix?      | no
New feature?  | no
BC breaks?    | yes
Deprecations? | no
Fixed tickets | N/A