### PR TITLE
Update ground-control.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     compile 'com.github.InkApplications:Prism:v0.1.1'
     compile 'com.inkapplications:android-simple-recycler-view:1.0.0'
     compile 'com.inkapplications:android-logger:1.1.0'
-    compile 'com.github.InkApplications:ground-control:v0.0.2'
+    compile 'com.github.InkApplications:ground-control:v0.0.4'
 
     compile 'com.android.support:support-v4:21.0.0'
     compile "com.android.support:appcompat-v7:21.0.0"
@@ -99,7 +99,9 @@ dependencies {
     compile 'com.jakewharton:butterknife:6.0.0'
 
     compile 'com.j256.ormlite:ormlite-android:4.48'
-    compile 'com.netflix.rxjava:rxjava-android:0.20.7'
+    compile('com.netflix.rxjava:rxjava-android:0.20.7') {
+        exclude module: "rxjava-core"
+    }
     compile 'com.squareup.dagger:dagger:1.2.2'
     provided 'com.squareup.dagger:dagger-compiler:1.2.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'

--- a/src/main/java/com/animedetour/android/database/DataModule.java
+++ b/src/main/java/com/animedetour/android/database/DataModule.java
@@ -33,6 +33,9 @@ import com.j256.ormlite.support.ConnectionSource;
 import dagger.Module;
 import dagger.Provides;
 import org.apache.commons.logging.Log;
+import rx.Scheduler;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
 
 import javax.inject.Singleton;
 import java.sql.SQLException;
@@ -46,7 +49,9 @@ final public class DataModule
         ScheduleEndpoint remote,
         Log logger
     ) {
-        SubscriptionFactory<Event> subscriptionFactory = new SubscriptionFactory<>(logger);
+        Scheduler main = AndroidSchedulers.mainThread();
+        Scheduler io = Schedulers.io();
+        SubscriptionFactory<Event> subscriptionFactory = new SubscriptionFactory<>(logger, io, main);
 
         try {
             Dao<Event, String> local = DaoManager.createDao(connectionSource, Event.class);
@@ -70,7 +75,9 @@ final public class DataModule
         GuestEndpoint remote,
         Log logger
     ) {
-        SubscriptionFactory<Category> subscriptionFactory = new SubscriptionFactory<>(logger);
+        Scheduler main = AndroidSchedulers.mainThread();
+        Scheduler io = Schedulers.io();
+        SubscriptionFactory<Category> subscriptionFactory = new SubscriptionFactory<>(logger, io, main);
 
         try {
             Dao<Category, Integer> localCategory = DaoManager.createDao(connectionSource, Category.class);


### PR DESCRIPTION
Updated the ground control library to 0.0.4 which required updating
some of the module configuration, including specifying work threads
and excluding rxjava-core from the rxandroid dependency, since it
is now provided through ground control at a newer version.

--------------------------------------------------------------------------------

Q             | A
--------------|-------
Bug fix?      | yes
New feature?  | no
BC breaks?    | no
Deprecations? | no
Fixed tickets | N/A