### PR TITLE
Add filtering to events.

### DIFF
--- a/src/main/java/com/animedetour/android/framework/Fragment.java
+++ b/src/main/java/com/animedetour/android/framework/Fragment.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Anime Detour Android application
  *
- * Copyright (c) 2014 Anime Twin Cities, Inc.
+ * Copyright (c) 2014-2015 Anime Twin Cities, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -10,6 +10,7 @@ package com.animedetour.android.framework;
 
 import android.os.Bundle;
 import butterknife.ButterKnife;
+import com.squareup.otto.Bus;
 import icepick.Icepick;
 import org.apache.commons.logging.Log;
 import prism.framework.PrismFacade;
@@ -20,6 +21,9 @@ public class Fragment extends android.support.v4.app.Fragment
 {
     @Inject
     Log logger;
+
+    @Inject
+    Bus applicationBus;
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState)
@@ -36,6 +40,20 @@ public class Fragment extends android.support.v4.app.Fragment
         super.onCreate(savedInstanceState);
 
         Icepick.restoreInstanceState(this, savedInstanceState);
+    }
+
+    @Override
+    public void onResume()
+    {
+        super.onResume();
+        this.applicationBus.register(this);
+    }
+
+    @Override
+    public void onPause()
+    {
+        super.onPause();
+        this.applicationBus.unregister(this);
     }
 
     @Override public void onSaveInstanceState(Bundle outState)

--- a/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ApplicationModule.java
+++ b/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ApplicationModule.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Anime Detour Android application
  *
- * Copyright (c) 2014 Anime Twin Cities, Inc.
+ * Copyright (c) 2014-2015 Anime Twin Cities, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -25,6 +25,7 @@ import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.Tracker;
 import com.inkapplications.groundcontrol.SubscriptionManager;
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.otto.Bus;
 import dagger.Module;
 import dagger.Provides;
 
@@ -76,5 +77,10 @@ final public class ApplicationModule
     @Provides @Singleton SubscriptionManager provideSubscriptionManager()
     {
         return new SubscriptionManager();
+    }
+
+    @Provides @Singleton Bus provideBus()
+    {
+        return new Bus();
     }
 }

--- a/src/main/java/com/animedetour/android/main/DrawerController.java
+++ b/src/main/java/com/animedetour/android/main/DrawerController.java
@@ -40,6 +40,7 @@ public class DrawerController extends ActionBarDrawerToggle
     final private Toolbar toolbar;
     final private DrawerLayout layout;
     private String title;
+    private boolean displayTitles = true;
 
     public DrawerController(
         Activity activity,
@@ -75,7 +76,9 @@ public class DrawerController extends ActionBarDrawerToggle
     {
         super.onDrawerOpened(drawerView);
 
-        this.toolbar.setTitle(R.string.app_name);
+        if (this.displayTitles) {
+            this.toolbar.setTitle(R.string.app_name);
+        }
         this.updateFavoritesVisibility();
     }
 
@@ -127,6 +130,7 @@ public class DrawerController extends ActionBarDrawerToggle
     {
         this.title = title;
         this.toolbar.setTitle(title);
+        this.displayTitles = true;
     }
 
     /**
@@ -172,5 +176,15 @@ public class DrawerController extends ActionBarDrawerToggle
     public void closeDrawer()
     {
         this.layout.closeDrawer(Gravity.START);
+    }
+
+    /**
+     * Hides the title of the page and prevents it from appearing when the
+     * drawer is opened.
+     */
+    public void disableTitles()
+    {
+        this.setTitle("");
+        this.displayTitles = false;
     }
 }

--- a/src/main/java/com/animedetour/android/main/NavigationSubContentUpdate.java
+++ b/src/main/java/com/animedetour/android/main/NavigationSubContentUpdate.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2015 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.main;
+
+import java.util.Set;
+
+/**
+ * Indicates a new set of data to display in the main navigation spinner as
+ * subcontent of the main component.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+final public class NavigationSubContentUpdate
+{
+    /**
+     * The elements to display as navigation options to the user.
+     */
+    final private Set<String> options;
+
+    /**
+     * @param options Elements to display as navigation options to the user.
+     */
+    public NavigationSubContentUpdate(Set<String> options)
+    {
+        this.options = options;
+    }
+
+    /**
+     * @return Elements to display as navigation options to the user.
+     */
+    public Set<String> getOptions()
+    {
+        return this.options;
+    }
+
+    /**
+     * @return Elements to display as navigation options to the user.
+     */
+    public String[] getOptionsArray()
+    {
+        if (null == this.options) {
+            return null;
+        }
+
+        return this.options.toArray(new String[this.options.size()]);
+    }
+}

--- a/src/main/java/com/animedetour/android/main/SpinnerEventProxy.java
+++ b/src/main/java/com/animedetour/android/main/SpinnerEventProxy.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2015 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.main;
+
+import android.view.View;
+import android.widget.AdapterView;
+import com.squareup.otto.Bus;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Listen for spinner selection events and proxy them into an event bus.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+@Singleton
+final public class SpinnerEventProxy implements AdapterView.OnItemSelectedListener
+{
+    final private Bus eventBus;
+
+    @Inject
+    public SpinnerEventProxy(Bus eventBus)
+    {
+        this.eventBus = eventBus;
+    }
+
+    @Override
+    public void onItemSelected(AdapterView parent, View view, int position, long id)
+    {
+        String selected = (String) parent.getItemAtPosition(position);
+        this.eventBus.post(new SubNavigationSelectionChange(selected));
+    }
+
+    @Override public void onNothingSelected(AdapterView adapterView) {}
+}

--- a/src/main/java/com/animedetour/android/main/SpinnerOptionContainer.java
+++ b/src/main/java/com/animedetour/android/main/SpinnerOptionContainer.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2015 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.main;
+
+/**
+ * Service that holds onto a spinner's state.
+ *
+ * @todo Refactor this to handle more than just stringly typed data.
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+public interface SpinnerOptionContainer
+{
+    /**
+     * Get the currently selected item in the spinner.
+     *
+     * @return The item currently selected in the spinner, or null if none is
+     *         available. Currently this is the exact string that is displayed
+     *         to the user in the spinner.
+     */
+    public String getSpinnerSelection();
+}

--- a/src/main/java/com/animedetour/android/main/SubNavigationSelectionChange.java
+++ b/src/main/java/com/animedetour/android/main/SubNavigationSelectionChange.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2015 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.main;
+
+/**
+ * Indicates that the sub-navigation of the application has been changed.
+ *
+ * This event will be dispatched every time the user changes the option
+ * in the actionbar spinner. Eg. when the user changes a filter on the event
+ * list, for instance.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+final public class SubNavigationSelectionChange
+{
+    /** The sub navigation item that the user has navigated to. */
+    final public String selection;
+
+    /**
+     * @param selection The sub navigation item that the user has navigated to.
+     */
+    public SubNavigationSelectionChange(String selection)
+    {
+        this.selection = selection;
+    }
+
+    /**
+     * @return The sub navigation item that the user has navigated to.
+     */
+    public String getSelection()
+    {
+        return selection;
+    }
+}

--- a/src/main/java/com/animedetour/android/schedule/EventFilterUpdater.java
+++ b/src/main/java/com/animedetour/android/schedule/EventFilterUpdater.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2015 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.schedule;
+
+import com.animedetour.android.main.NavigationSubContentUpdate;
+import com.animedetour.api.sched.api.model.Event;
+import com.squareup.otto.Bus;
+import org.apache.commons.logging.Log;
+import rx.Observer;
+
+import javax.inject.Inject;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Service for sending out navigation updtates based on available event types
+ * to filer on.
+ *
+ * This listens for updates to a collection of events, finds each of the unique
+ * event types available, and sends out an event on the bus with the distinct
+ * types.
+ *
+ * @todo replace this with a query just for the types instead of an entire collection.
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+final public class EventFilterUpdater implements Observer<List<Event>>
+{
+    /**
+     * Tag to inject at the top of the list to use as a filter for all the events.
+     *
+     * @todo Localization issue here; find a way to remove this string.
+     */
+    final public static String ALL_EVENTS = "All Events";
+
+    /** Event bus to dispatch the navigation content changes onto. */
+    final private Bus applicationBus;
+
+    /** Log used when requests come back with errors. */
+    final private Log logger;
+
+    /**
+     * @param applicationBus Event bus to dispatch the navigation content changes onto.
+     * @param logger Log used when requests come back with errors.
+     */
+    @Inject
+    public EventFilterUpdater(Bus applicationBus, Log logger)
+    {
+        this.applicationBus = applicationBus;
+        this.logger = logger;
+    }
+
+    @Override
+    public void onNext(List<Event> events)
+    {
+        Set<String> types = new TreeSet<>();
+        types.add(ALL_EVENTS);
+
+        for (Event event : events) {
+            if (null == event.getEventType()) {
+                continue;
+            }
+            types.add(event.getEventType());
+        }
+
+        this.applicationBus.post(new NavigationSubContentUpdate(types));
+    }
+
+    @Override
+    public void onError(Throwable e)
+    {
+        this.logger.error("Error loading events for filter updater", e);
+    }
+
+    @Override public void onCompleted() {}
+}

--- a/src/main/java/com/animedetour/android/schedule/EventUpdateSubscriber.java
+++ b/src/main/java/com/animedetour/android/schedule/EventUpdateSubscriber.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Anime Detour Android application
  *
- * Copyright (c) 2014 Anime Twin Cities, Inc.
+ * Copyright (c) 2014-2015 Anime Twin Cities, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,6 +15,7 @@ import com.inkapplications.android.widget.listview.ItemAdapter;
 import org.apache.commons.logging.Log;
 import rx.Subscriber;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -57,6 +58,19 @@ public class EventUpdateSubscriber extends Subscriber<List<Event>>
      */
     private boolean restored = false;
 
+    /**
+     * The most recent collection of events received.
+     *
+     * This is needed to be used as a reference when changing filters for what
+     * is displayed in the list.
+     */
+    private List<Event> events = new ArrayList<>();
+
+    /**
+     * Currently displayed filter. (default: all)
+     */
+    private String filterType = EventFilterUpdater.ALL_EVENTS;
+
     public EventUpdateSubscriber(
         ListView panelList,
         ItemAdapter<PanelView, Event> listAdapter,
@@ -82,6 +96,45 @@ public class EventUpdateSubscriber extends Subscriber<List<Event>>
 
     @Override
     public void onNext(List<Event> events)
+    {
+        this.events = events;
+        this.displayFiltered(this.filterType);
+    }
+
+    /**
+     * Change the events displayed by a specified type filter.
+     *
+     * @param filterType The Event type to only display events of.
+     */
+    public void displayFiltered(String filterType)
+    {
+        this.filterType = filterType;
+        ArrayList<Event> filtered = new ArrayList<>();
+
+        if (null == filterType || filterType.equals(EventFilterUpdater.ALL_EVENTS)) {
+            this.displayEvents(this.events);
+            return;
+        }
+
+        for (Event event : this.events) {
+            String type = event.getEventType();
+            if (null ==  type || false == type.equals(filterType)) {
+                continue;
+            }
+            filtered.add(event);
+        }
+
+        this.displayEvents(filtered);
+    }
+
+    /**
+     * Change the items displayed in the event list.
+     *
+     * If the list is empty, this will toggle an empty view to be displayed.
+     *
+     * @param events The list of events to display.
+     */
+    private void displayEvents(List<Event> events)
     {
         this.toggleEmptyView(events.isEmpty());
         this.itemAdapter.setItems(events);

--- a/src/main/java/com/animedetour/android/schedule/ScheduleFragment.java
+++ b/src/main/java/com/animedetour/android/schedule/ScheduleFragment.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Anime Detour Android application
  *
- * Copyright (c) 2014 Anime Twin Cities, Inc.
+ * Copyright (c) 2014-2015 Anime Twin Cities, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,10 +15,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import butterknife.InjectView;
 import com.animedetour.android.R;
+import com.animedetour.android.database.event.EventRepository;
 import com.animedetour.android.framework.Fragment;
 import com.inkapplications.prism.analytics.ScreenName;
+import com.squareup.otto.Bus;
 import org.joda.time.DateTime;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +37,15 @@ final public class ScheduleFragment extends Fragment
 {
     @InjectView(R.id.event_days)
     ViewPager pager;
+
+    @Inject
+    Bus applicationBus;
+
+    @Inject
+    EventRepository eventData;
+
+    @Inject
+    EventFilterUpdater filterUpdater;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
@@ -54,6 +66,7 @@ final public class ScheduleFragment extends Fragment
             this.getDays()
         );
         this.pager.setAdapter(pagerAdapter);
+        this.eventData.findAll(this.filterUpdater);
     }
 
     /**

--- a/src/main/res/layout/main.xml
+++ b/src/main/res/layout/main.xml
@@ -15,7 +15,15 @@
         app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         android:background="@color/primary"
-    />
+    >
+        <Spinner
+            android:id="@+id/spinner_nav"
+            android:visibility="gone"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+        />
+    </android.support.v7.widget.Toolbar>
+
     <android.support.v4.widget.DrawerLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/drawer_layout"

--- a/src/main/res/layout/main_navigation_spinner_item.xml
+++ b/src/main/res/layout/main_navigation_spinner_item.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/title"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:textColor="@color/foreground_inverse"
+    tools:text="Anime Detour Panel"
+/>


### PR DESCRIPTION
Adds a sub-navigation spinner to the main activity that allows
the user to drill down into subcontent.
Added filtering by event type by selecting the category in the
sub navigation spinner.
Some cleanup is necesary here, but the base functionality is
working.

Q             | A
--------------|-------
Bug fix?      | no
New feature?  | yes
BC breaks?    | no
Deprecations? | no
Fixed tickets | N/A