### PR TITLE
Modify build config to use parameter for build #

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ if (skipProguard) {
     logger.warn('WARNING: Skipping proguard will only work for devices running Android 21+ !!')
 }
 
+def rev = project.hasProperty("versionCode") ? project.getProperty("versionCode") : 2000;
+
 android {
     compileSdkVersion 'android-21'
     buildToolsVersion '21.1.2'
@@ -22,7 +24,7 @@ android {
         applicationId "org.animetwincities.animedetour"
         minSdkVersion  (skipProguard ? 21 : 16)
         targetSdkVersion 21
-        versionCode 1003
+        versionCode rev
         versionName "2.2.0"
         multiDexEnabled skipProguard
     }


### PR DESCRIPTION
Instead of incrementing the build number, we're going to pass it in
with `-PversionCode=1234` so that jenkins can always increment the
version on its own.
If not supplied, it will use build #2000, in order to not cause
conflicts with other version numbers.

--------------------------------------------------------------------------------

Q             | A
--------------|-------
Bug fix?      | no
New feature?  | no
BC breaks?    | no
Deprecations? | no
Fixed tickets | [trello-82]

[trello-82]: https://trello.com/c/j1lOEgBt
