### PR TITLE
Allow strings to be used in the list persister.

### DIFF
--- a/src/main/java/com/animedetour/android/database/persiseter/ImplodedListPersister.java
+++ b/src/main/java/com/animedetour/android/database/persiseter/ImplodedListPersister.java
@@ -20,6 +20,11 @@ import java.util.List;
 /**
  * Persists a List of Strings to a comma separated string in the database.
  *
+ * When converting to the SQL string type, if a string is provided as an
+ * argument instead of a list the argument will not be modified. This happens
+ * during search queries to the database, since those will be matched on a
+ * string from the application as well.
+ *
  * @author Maxwell Vandervelde <Max@MaxVandervelde.com>
  */
 public class ImplodedListPersister extends StringType
@@ -50,6 +55,10 @@ public class ImplodedListPersister extends StringType
     @Override
     public Object javaToSqlArg(FieldType fieldType, Object javaObject) throws SQLException
     {
+        if (javaObject instanceof String) {
+            return javaObject;
+        }
+
         if (false == javaObject instanceof List) {
             throw new RuntimeException("Persistence requires that this field be a list");
         }

--- a/src/test/java/com/animedetour/android/database/persiseter/ImplodedListPersisterTest.java
+++ b/src/test/java/com/animedetour/android/database/persiseter/ImplodedListPersisterTest.java
@@ -19,6 +19,10 @@ public class ImplodedListPersisterTest
 {
     private final ImplodedListPersister subject = new ImplodedListPersister();
 
+    /**
+     * Make sure the perister can convert the comma-separated values as they
+     * are in the database into a proper java list.
+     */
     @Test
     public void testSqlArgToJava() throws Exception
     {
@@ -31,6 +35,10 @@ public class ImplodedListPersisterTest
         assertEquals("baz", result.get(2));
     }
 
+    /**
+     * Make sure the persister can convert a java list into a proper
+     * comma-separated value string to be inserted into the database.
+     */
     @Test
     public void testJavaToSqlArg() throws Exception
     {
@@ -38,5 +46,17 @@ public class ImplodedListPersisterTest
         String result = (String) this.subject.javaToSqlArg(null, arguments);
 
         assertEquals("foo,bar,baz", result);
+    }
+
+    /**
+     * Objects that are already strings should be allowed to be passed directly
+     * into the database unchanged.
+     */
+    @Test
+    public void testSearchArgToSqlArg() throws Exception
+    {
+        String result = (String) this.subject.javaToSqlArg(null, "%test%");
+
+        assertEquals("%test%", result);
     }
 }


### PR DESCRIPTION
Apperently strings are passed directly through the persisters.
Allowed the string to pass through the persister unmodified and added
a test to ensure this functionality.

------------------------------------------------------------------------

Q              | A
---------------|-------
Target Release | v2.2.0
Bug fix?       | yes
New feature?   | no
BC breaks?     | no
Deprecations?  | no
Fixed tickets  | n/a