### PR TITLE
Age labels

### DIFF
--- a/src/main/java/com/animedetour/android/schedule/EventActivity.java
+++ b/src/main/java/com/animedetour/android/schedule/EventActivity.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Anime Detour Android application
  *
- * Copyright (c) 2014 Anime Twin Cities, Inc.
+ * Copyright (c) 2014,2016 Anime Twin Cities, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.text.Html;
-import android.text.TextUtils;
 import android.view.View;
 import android.widget.ScrollView;
 import android.widget.TextView;

--- a/src/main/java/com/animedetour/android/schedule/EventActivity.java
+++ b/src/main/java/com/animedetour/android/schedule/EventActivity.java
@@ -94,6 +94,9 @@ final public class EventActivity extends BaseActivity
     @Bind(R.id.event_container)
     ScrollView detailsContainer;
 
+    @Bind(R.id.event_age_warning)
+    TextView ageWarning;
+
     @Inject
     Monolog logger;
 
@@ -156,6 +159,18 @@ final public class EventActivity extends BaseActivity
             this.descriptionView.setText("");
         }
         this.bannerView.setTitle(this.event.getName());
+
+        if (this.event.getTags().contains("21+")) {
+            String warning = this.getString(R.string.event_age_warning, "21+");
+            this.ageWarning.setText(warning);
+            this.ageWarning.setVisibility(View.VISIBLE);
+        } else if (this.event.getTags().contains("18+")) {
+            String warning = this.getString(R.string.event_age_warning, "18+");
+            this.ageWarning.setText(warning);
+            this.ageWarning.setVisibility(View.VISIBLE);
+        } else {
+            this.ageWarning.setVisibility(View.GONE);
+        }
 
         String type = this.event.getCategory();
         this.eventType.setText(type);

--- a/src/main/java/com/animedetour/android/schedule/PanelView.java
+++ b/src/main/java/com/animedetour/android/schedule/PanelView.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Anime Detour Android application
  *
- * Copyright (c) 2014 Anime Twin Cities, Inc.
+ * Copyright (c) 2014,2016 Anime Twin Cities, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/main/java/com/animedetour/android/schedule/PanelView.java
+++ b/src/main/java/com/animedetour/android/schedule/PanelView.java
@@ -52,6 +52,11 @@ public class PanelView extends RelativeLayout
      */
     private View fadeOverlay;
 
+    /**
+     * A label to quickly indicate a minimum age for the event.
+     */
+    private TextView ageWarning;
+
     private View color;
 
     /**
@@ -94,6 +99,7 @@ public class PanelView extends RelativeLayout
         this.fadeOverlay = this.findViewById(R.id.view_panel_overlay);
         this.starred = (ImageView) this.findViewById(R.id.view_panel_starred);
         this.color = this.findViewById(R.id.view_panel_color_label);
+        this.ageWarning = (TextView) this.findViewById(R.id.view_panel_age_warning);
     }
 
     /**
@@ -143,6 +149,16 @@ public class PanelView extends RelativeLayout
             this.fadeOverlay.setVisibility(VISIBLE);
         } else {
             this.fadeOverlay.setVisibility(GONE);
+        }
+
+        if (event.getTags().contains("18+")) {
+            this.ageWarning.setText("18+");
+            this.ageWarning.setVisibility(VISIBLE);
+        } else if (event.getTags().contains("21+")) {
+            this.ageWarning.setText("21+");
+            this.ageWarning.setVisibility(VISIBLE);
+        } else {
+            this.ageWarning.setVisibility(GONE);
         }
     }
 

--- a/src/main/res/layout/event.xml
+++ b/src/main/res/layout/event.xml
@@ -82,6 +82,15 @@
                         android:layout_height="wrap_content"
                         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a ex nec felis fermentum euismod quis id eros. Etiam sit amet diam et massa malesuada blandit. Duis lectus nisl, rutrum non scelerisque ac, bibendum aliquam ligula. Morbi tempor nisl lectus, a sodales felis aliquet eget. Nunc nec ipsum libero. Vivamus ultrices nunc eget orci pharetra pellentesque. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nam id nulla quam. Nam nec tempus elit. Aenean quis erat eu turpis sodales mattis. Etiam tempor ultricies nisi, vitae aliquet ligula vestibulum vitae. Nunc tincidunt dictum dolor, condimentum imperdiet nisl blandit et. Nulla facilisi. Praesent et est lorem."
                     />
+                    <TextView
+                        android:id="@+id/event_age_warning"
+                        style="@style/body1"
+                        android:padding="16dp"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/danger_dim"
+                        tools:text="Parts of this event may be restricted to ages of 21+ \nYou may be required to show your ID at the door"
+                    />
                 </LinearLayout>
                 <com.animedetour.android.view.StarFloatingActionButton
                     android:id="@+id/event_add"

--- a/src/main/res/layout/view_panel.xml
+++ b/src/main/res/layout/view_panel.xml
@@ -7,7 +7,7 @@
     android:id="@+id/card_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:layout_height="75dp"
+    tools:layout_height="80dp"
     card_view:elevation="1dp"
     card_view:cardCornerRadius="0dp"
     android:layout_margin="4dp"
@@ -24,33 +24,40 @@
             tools:background="@color/success"
         />
         <RelativeLayout
+            style="@style/panel"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:background="@drawable/drawer_row_background"
         >
-            <LinearLayout
-                style="@style/panel"
-                android:orientation="vertical"
+            <TextView
+                style="@style/title"
+                android:id="@+id/view_panel_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginRight="40dp"
+                android:singleLine="true"
+                android:ellipsize="end"
+                tools:text="Panel Name"
+            />
+            <TextView
+                android:id="@+id/view_panel_age_warning"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_toRightOf="@id/view_panel_name"
+                android:layout_toEndOf="@id/view_panel_name"
+                android:layout_marginLeft="-32dp"
+                android:textColor="@color/danger"
+                tools:text="18+"
+            />
+
+            <TextView
+                style="@style/caption"
+                android:id="@+id/view_panel_description"
+                android:layout_below="@id/view_panel_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/drawer_row_background"
-            >
-                <TextView
-                    style="@style/title"
-                    android:id="@+id/view_panel_name"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="32dp"
-                    tools:text="Panel Name"
-                />
-
-                <TextView
-                    style="@style/caption"
-                    android:id="@+id/view_panel_description"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    tools:text="1:00 - 4:00 in Room B"
-                />
-            </LinearLayout>
+                tools:text="1:00 - 4:00 in Room B"
+            />
             <com.animedetour.android.view.ColoredImageView
                 android:id="@+id/view_panel_starred"
                 android:visibility="gone"
@@ -69,5 +76,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/background_faded"
+        tools:visibility="gone"
     />
 </android.support.v7.widget.CardView>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -45,4 +45,5 @@
     <string name="event_search_no_results">No results</string>
     <string name="event_search_no_results_description">No events found with that title</string>
     <string name="guest_empty_subhead">Guests will show here.</string>
+    <string name="event_age_warning">Parts of this event may be restricted to %s \nYou may be required to show your ID before entering.</string>
 </resources>


### PR DESCRIPTION
For events marked as 18/21+ we show a little badge to indicate this
in the index, as a warning.
Removed the linear layout wrapping text on the panel views so that
the badge can float to the right of the title and forced the title to
fit on one line, so it looks good.

Added a more detailed message inside of the event view about
whether the event may be restricted to ages 21/18 and up.

------------------------------------------------------------------------

| Q              | A
| -------------- | ---
| Target Release | v2.2.0
| Bug fix?       | no
| New feature?   | yes
| Deprecations?  | no
| Fixed tickets  | [trello-97](https://trello.com/c/xVEbMBvI)

