### PR TITLE
Fix electronic gaming color to be blue.

### DIFF
--- a/src/main/java/com/animedetour/android/schedule/EventPalette.java
+++ b/src/main/java/com/animedetour/android/schedule/EventPalette.java
@@ -76,7 +76,7 @@ public class EventPalette
             return R.color.label_panel;
         }
 
-        if (type.equals("Video Gaming")) {
+        if (type.equals("Electronic Gaming")) {
             return R.color.label_videogame;
         }
 
@@ -132,7 +132,7 @@ public class EventPalette
             return R.color.label_panel_dim;
         }
 
-        if (type.equals("Video Gaming")) {
+        if (type.equals("Electronic Gaming")) {
             return R.color.label_videogame_dim;
         }
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Target Release | v2.2.0
| New feature?   | yes
| Deprecations?  | no
| Fixed tickets  | n/a

------------------------------------------------------------------------


Now it matches the other gaming category.
we really need to fix this up so it's not hardcoded sometime.