### PR TITLE
Re-submit search query on resume

### DIFF
--- a/src/main/java/com/animedetour/android/schedule/serach/EventSearchActivity.java
+++ b/src/main/java/com/animedetour/android/schedule/serach/EventSearchActivity.java
@@ -107,6 +107,7 @@ final public class EventSearchActivity extends BaseActivity
             this.filters
         );
         this.searchBar.setOnQueryTextListener(queryListener);
+        queryListener.onQueryTextChange(this.searchBar.getQuery().toString());
     }
 
     @Override


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Target Release | v2.2.0
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Fixed tickets  | [trello-101](https://trello.com/c/KlH4NVWc)

------------------------------------------------------------------------


Previously, when you clicked on something in the search results and
then hit back, the search query wouldn't be showing any results.
Fixed this by re-submitting the query to the listener on resume.