### PR TITLE
Update Thumbnails on guest index

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,8 +131,8 @@ dependencies {
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.3'
     compile 'joda-time:joda-time:2.9.1'
     compile 'org.joda:joda-convert:1.8.1'
-    compile 'com.facebook.fresco:fresco:0.8.1'
-    compile "com.facebook.fresco:imagepipeline-okhttp:0.8.1"
+    compile 'com.facebook.fresco:fresco:0.9.0'
+    compile "com.facebook.fresco:imagepipeline-okhttp:0.9.0"
     compile 'org.javatuples:javatuples:1.2'
     compile 'com.google.guava:guava:18.0'
 

--- a/src/main/java/com/animedetour/android/guest/GuestWidgetView.java
+++ b/src/main/java/com/animedetour/android/guest/GuestWidgetView.java
@@ -9,6 +9,7 @@
 package com.animedetour.android.guest;
 
 import android.content.Context;
+import android.graphics.PointF;
 import android.net.Uri;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -53,6 +54,7 @@ public class GuestWidgetView extends FrameLayout
 
         LayoutInflater.from(context).inflate(R.layout.guest_widget_view, this);
         this.image = (SimpleDraweeView) this.findViewById(R.id.guest_widget_image);
+        this.image.getHierarchy().setActualImageFocusPoint(new PointF(.5f, .38f));
         this.name = (TextView) this.findViewById(R.id.guest_widget_name);
     }
 
@@ -65,7 +67,7 @@ public class GuestWidgetView extends FrameLayout
     public void bindGuest(Guest guest)
     {
         this.setName(guest.getFullName());
-        this.setImageUri(guest.getFullPhoto());
+        this.setImageUri(guest.getPhoto());
     }
 
     /**

--- a/src/main/res/layout/guest_widget_view.xml
+++ b/src/main/res/layout/guest_widget_view.xml
@@ -13,6 +13,7 @@
         android:layout_width="88dp"
         android:layout_height="88dp"
         android:layout_centerHorizontal="true"
+        app:actualImageScaleType="focusCrop"
         app:placeholderImage="@drawable/account_96dp"
         app:roundAsCircle="true"
     />


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Target Release | v2.2.0
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Fixed tickets  | n/a

------------------------------------------------------------------------


The thumbnails on the guest index used to be using the full image,
that has now been changed to use the thumbnail. This combined with
updating fresco seems to have resolved the memory issue.
Made the new thumbnails focus crop lower on the image so people's
faces will be more centered like the scrim in the details.