### PR TITLE
Allow eventt titles to be multi-line

### DIFF
--- a/src/main/res/layout/view_panel.xml
+++ b/src/main/res/layout/view_panel.xml
@@ -42,8 +42,6 @@
                     android:layout_width="0dp"
                     android:layout_weight="1"
                     android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:ellipsize="end"
                     tools:text="Panel Name XXXXXXXXXXXXXXXX"
                 />
                 <TextView


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Target Release | v2.2.0
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Fixed tickets  | n/a

------------------------------------------------------------------------


This was cutting off too early for some reason, but the long titles
no longer conflict with the layout, so I'm going to remove it for now.