### PR TITLE
Allow loading indicators to run.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     compile 'com.github.InkApplications:android-monolog:v0.1.0'
     compile 'com.github.InkApplications:Prism:v1.1.0@aar'
     compile 'com.github.InkApplications:android-simple-recycler-view:v1.0.2'
-    compile 'com.github.InkApplications:ground-control:v0.2.0'
+    compile 'com.github.InkApplications:ground-control:v0.3.0'
 
     compile 'com.android.support:support-v4:23.1.0'
     compile "com.android.support:appcompat-v7:23.1.0"


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Target Release | v2.2.0
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Fixed tickets  | n/a

------------------------------------------------------------------------


An update in a 3rd party library causes the local data to not return
results when the first load is made. this allows the progress indicators
to have a chance to run now.