### PR TITLE
Hide spinner when favorites are loaded.

### DIFF
--- a/src/main/java/com/animedetour/android/schedule/favorite/FavoriteUpdateObserver.java
+++ b/src/main/java/com/animedetour/android/schedule/favorite/FavoriteUpdateObserver.java
@@ -24,17 +24,20 @@ import java.util.List;
  */
 public class FavoriteUpdateObserver implements Observer<List<Favorite>>
 {
-    private FavoritesFragment fragment;
-    private View emptyView;
-    private Monolog logger;
+    final private FavoritesFragment fragment;
+    final private View emptyView;
+    final private View loadingIndicator;
+    final private Monolog logger;
 
     public FavoriteUpdateObserver(
         FavoritesFragment fragment,
         View emptyView,
+        View loadingIndicator,
         Monolog logger
     ) {
         this.fragment = fragment;
         this.emptyView = emptyView;
+        this.loadingIndicator = loadingIndicator;
         this.logger = logger;
     }
 
@@ -49,6 +52,10 @@ public class FavoriteUpdateObserver implements Observer<List<Favorite>>
     @Override
     public void onNext(List<Favorite> favorites)
     {
+        if (null != this.loadingIndicator) {
+            this.loadingIndicator.setVisibility(View.GONE);
+        }
+
         if (favorites.size() == 0) {
             this.emptyView.setVisibility(View.VISIBLE);
         } else {

--- a/src/main/java/com/animedetour/android/schedule/favorite/FavoritesFragment.java
+++ b/src/main/java/com/animedetour/android/schedule/favorite/FavoritesFragment.java
@@ -57,6 +57,9 @@ final public class FavoritesFragment extends BaseFragment
     @Bind(R.id.panel_empty_view)
     View panelEmptyView;
 
+    @Bind(R.id.events_loading_indicator)
+    View loadingIndicator;
+
     @Inject
     SubscriptionManager subscriptionManager;
 
@@ -101,7 +104,7 @@ final public class FavoritesFragment extends BaseFragment
         this.panelList.setAdapter(adapter);
 
         Subscription favoriteSubscription = this.favoriteData.findAll(
-            new FavoriteUpdateObserver(this, this.panelEmptyView, this.logger)
+            new FavoriteUpdateObserver(this, this.panelEmptyView, this.loadingIndicator, this.logger)
         );
         this.subscriptionManager.add(favoriteSubscription);
     }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Target Release | v2.2.0
| Bug fix?       | yes
| New feature?   | no
| Deprecations?  | no
| Fixed tickets  | [trello-104](https://trello.com/c/zw3YkI0D)

------------------------------------------------------------------------


The favorites view re-uses the layout for the events page, so when
we added a spinner to that page, it needed to be hidden on the
favorites page as well.