### PR TITLE
fix bugs with event searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v2.2.1
  * Change panel times to display days.
  * Fix floating badge issue
  * Add Tags to event details
+ * Improvements to search
 
 v2.2.0
 ---------------------

--- a/src/main/java/com/animedetour/android/database/event/AllEventsMatchingWorker.java
+++ b/src/main/java/com/animedetour/android/database/event/AllEventsMatchingWorker.java
@@ -16,6 +16,7 @@ import com.animedetour.api.sched.model.ApiEvent;
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.stmt.PreparedQuery;
 import com.j256.ormlite.stmt.QueryBuilder;
+import com.j256.ormlite.stmt.SelectArg;
 import monolog.Monolog;
 
 import java.sql.SQLException;
@@ -60,10 +61,11 @@ public class AllEventsMatchingWorker extends SyncEventsWorker
 
         String criteria = this.criteria.trim();
 
-        builder.where().like("name","%" + criteria + "%")
-            .or().eq("category", criteria)
-            .or().like("tags", "%" + criteria + "%")
-            .or().like("hosts", "%" + criteria + "%");
+        builder.where().like("name", new SelectArg("%" + criteria + "%"))
+            .or().eq("category", new SelectArg(criteria))
+            .or().like("tags", new SelectArg("%" + criteria + "%"))
+            .or().like("hosts", new SelectArg("%" + criteria + "%"))
+            .or().like("room", new SelectArg("%" + criteria + "%"));
 
         PreparedQuery<Event> query = builder.prepare();
         List<Event> result = this.localAccess.query(query);


### PR DESCRIPTION
The event search had a couple of issues: Arguments weren't being
escaped, so anything with a special character would error (not crash)
Rooms weren't being searched, so there was no way to find events in a
specific room

------------------------------------------------------------------------

| Q              | A
| -------------- | ---
| Target Release | v2.2.1
| Bug fix?       | yes
| New feature?   | yes
| Deprecations?  | no
| Fixed tickets  | [trello-107](https://trello.com/c/hfxrYsf1)



