### PR TITLE
Off season improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ android {
         minSdkVersion  (skipProguard ? 21 : 16)
         targetSdkVersion 23
         versionCode rev
-        versionName "2.3.0"
+        versionName "2.4.0"
         multiDexEnabled skipProguard
     }
 

--- a/src/main/java/com/animedetour/android/analytics/EventFactory.java
+++ b/src/main/java/com/animedetour/android/analytics/EventFactory.java
@@ -58,4 +58,14 @@ final public class EventFactory
     {
         return new TrackedEvent("Settings", "Dev-enable");
     }
+
+    public static TrackedEvent moreEventsClick()
+    {
+        return new TrackedEvent("Home", "More Events");
+    }
+
+    public static TrackedEvent registerClick()
+    {
+        return new TrackedEvent("Home", "Register");
+    }
 }

--- a/src/main/java/com/animedetour/android/database/event/AllEventsByDayWorker.java
+++ b/src/main/java/com/animedetour/android/database/event/AllEventsByDayWorker.java
@@ -71,6 +71,9 @@ public class AllEventsByDayWorker extends SyncEventsWorker
     {
         DateTime dayCriteria = this.criteria.getValue0();
         Boolean includePast = this.criteria.getValue1();
+        if (dayCriteria.withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59).isBefore(DateTime.now())) {
+            includePast = true;
+        }
         DateTime now = new DateTime();
 
         DateTime start = dayCriteria.withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0);

--- a/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ActivityModule.java
+++ b/src/main/java/com/animedetour/android/framework/dependencyinjection/module/ActivityModule.java
@@ -11,6 +11,7 @@ package com.animedetour.android.framework.dependencyinjection.module;
 import com.animedetour.android.guest.GuestDetailActivity;
 import com.animedetour.android.guest.GuestIndexFragment;
 import com.animedetour.android.home.HomeFragment;
+import com.animedetour.android.home.OffSeasonHomeFragment;
 import com.animedetour.android.main.MainActivity;
 import com.animedetour.android.map.HotelMapFragment;
 import com.animedetour.android.schedule.DayFragment;
@@ -29,6 +30,7 @@ import dagger.Module;
         EventSearchActivity.class,
 
         HomeFragment.class,
+        OffSeasonHomeFragment.class,
         DayFragment.class,
         ScheduleFragment.class,
         GuestIndexFragment.class,

--- a/src/main/java/com/animedetour/android/home/OffSeasonHomeFragment.java
+++ b/src/main/java/com/animedetour/android/home/OffSeasonHomeFragment.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the Anime Detour Android application
+ *
+ * Copyright (c) 2016 Anime Twin Cities, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package com.animedetour.android.home;
+
+import android.content.Intent;
+import android.net.Uri;
+import butterknife.OnClick;
+import com.animedetour.android.R;
+import com.animedetour.android.analytics.EventFactory;
+import com.animedetour.android.framework.BaseFragment;
+import monolog.LogName;
+import monolog.Monolog;
+import prism.framework.DisplayName;
+import prism.framework.Layout;
+
+import javax.inject.Inject;
+
+/**
+ * The off-season Landing / Home fragment.
+ *
+ * This fragment is displayed by default when you open the app ONLY IF:
+ * the previous convention is over, AND the next year's schedule is not yet
+ * available.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+@DisplayName(R.string.home_title)
+@LogName("Home")
+@Layout(R.layout.landing_off_season)
+final public class OffSeasonHomeFragment extends BaseFragment
+{
+    @Inject
+    Monolog logger;
+
+    @OnClick(R.id.register_next_year)
+    public void registerAction()
+    {
+        this.logger.trace(EventFactory.registerClick());
+
+        String url = "http://animedetour.com/register";
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW);
+        browserIntent.setData(Uri.parse(url));
+        startActivity(browserIntent);
+    }
+
+    @OnClick(R.id.more_events)
+    public void moreEventsAction()
+    {
+        this.logger.trace(EventFactory.moreEventsClick());
+
+        String url = "http://animetwincities.org/sos";
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW);
+
+        browserIntent.setData(Uri.parse(url));
+        startActivity(browserIntent);
+    }
+}

--- a/src/main/java/com/animedetour/android/main/MainActivity.java
+++ b/src/main/java/com/animedetour/android/main/MainActivity.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Anime Detour Android application
  *
- * Copyright (c) 2014-2015 Anime Twin Cities, Inc.
+ * Copyright (c) 2014-2016 Anime Twin Cities, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -21,6 +21,7 @@ import com.animedetour.android.R;
 import com.animedetour.android.framework.BaseActivity;
 import com.animedetour.android.guest.GuestIndexFragment;
 import com.animedetour.android.home.HomeFragment;
+import com.animedetour.android.home.OffSeasonHomeFragment;
 import com.animedetour.android.map.HotelMapFragment;
 import com.animedetour.android.schedule.ScheduleFragment;
 import com.animedetour.android.schedule.favorite.FavoritesFragment;
@@ -31,6 +32,7 @@ import javax.inject.Inject;
 import butterknife.Bind;
 import butterknife.OnClick;
 import icepick.State;
+import org.joda.time.DateTime;
 import prism.framework.Layout;
 
 /**
@@ -112,7 +114,13 @@ final public class MainActivity extends BaseActivity
     protected void openLandingFragment()
     {
         this.drawerController.closeToPage(HomeFragment.class);
-        this.contentFragmentTransaction(new HomeFragment(), "home");
+
+        // @todo – Remove this hardcoded date check when the API has the capability to lookup convention dates (soon, I promise)
+        if (DateTime.now().isAfter(new DateTime("2016-04-24").withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59))) {
+            this.contentFragmentTransaction(new OffSeasonHomeFragment(), "home");
+        } else {
+            this.contentFragmentTransaction(new HomeFragment(), "home");
+        }
     }
 
     /**

--- a/src/main/res/layout/landing_off_season.xml
+++ b/src/main/res/layout/landing_off_season.xml
@@ -1,0 +1,45 @@
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/default_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+>
+    <TextView
+        style="@style/display1"
+        android:layout_centerInParent="true"
+        android:textColor="@color/foreground_highlight"
+        android:fontFamily="sans-serif-thin"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/off_season_headline"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="16dp"
+        android:paddingBottom="48dp"
+    />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+    >
+        <Button
+            android:id="@+id/more_events"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textColor="@color/foreground_inverse"
+            android:layout_margin="16dp"
+            android:padding="16dp"
+            android:text="@string/atc_link"
+            android:layout_weight=".5"
+        />
+        <Button
+            android:theme="@style/button_primary"
+            android:id="@+id/register_next_year"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:padding="16dp"
+            android:text="@string/register_action"
+            android:layout_weight=".5"
+        />
+    </LinearLayout>
+</RelativeLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -49,4 +49,7 @@
     <string name="event_age_warning">Parts of this event may be restricted to %s \nYou may be required to show your ID before entering.</string>
     <string name="missing_google_play_services_error_message">Oh no! We can\'t show you this map, since you don\'t have Google Play Services!</string>
     <string name="google_play_services_button_label">Get Google Play Services</string>
+    <string name="off_season_headline">Join Us Next Year!</string>
+    <string name="atc_link">More Events</string>
+    <string name="register_action">Register</string>
 </resources>

--- a/src/main/res/values/styles.xml
+++ b/src/main/res/values/styles.xml
@@ -43,4 +43,14 @@
     <style name="panel">
         <item name="android:padding">16dp</item>
     </style>
+    <style name="button_primary" parent="Theme.AppCompat.Light">
+        <item name="colorControlHighlight">@color/primary_highlight</item>
+        <item name="colorButtonNormal">@color/primary</item>
+        <item name="android:textColor">@color/foreground_inverse</item>
+    </style>
+    <style name="button_secondary" parent="Theme.AppCompat.Light">
+        <item name="colorControlHighlight">#22000000</item>
+        <item name="colorButtonNormal">@android:color/transparent</item>
+        <item name="android:textColor">#ff3949AB</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Force events to return if event day is in the past.
Previously, ended events would only show if the "show hidden events"
option was selected. However, this causes an empty screen after the con
day is over. So it makes more sense to only hide events that are over on
that day, and show all of them again once that event is in the past.

## Add an off-season homepage
This adds a different homepage that will display a headline and some
links for more events and registration for the next year.

Fixes #75 