### PR TITLE
Gradle update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 /captures
 .externalNativeBuild
+.idea/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
 
     compile 'frankiesardo:icepick:3.1.0'
-    provided 'frankiesardo:icepick-processor:3.1.0'
+    annotationProcessor 'frankiesardo:icepick-processor:3.1.0'
 
     compile 'com.github.InkApplications:android-logger:4.1.0'
     compile 'com.github.InkApplications:android-layout-injector:1.1.0'
@@ -110,4 +110,3 @@ tasks.withType(Test) {
 }
 
 apply plugin: 'com.google.gms.google-services'
-apply plugin: 'me.tatarka.retrolambda'

--- a/app/src/main/java/org/animetwincities/animedetour/guest/GuestRepository.java
+++ b/app/src/main/java/org/animetwincities/animedetour/guest/GuestRepository.java
@@ -74,7 +74,9 @@ public class GuestRepository
             .take(1)
             .flatMapCompletable(guests -> Observable.fromIterable(guests)
                 .map(Guest::getImage)
-                .flatMapCompletable(url -> FrescoObservables.prefetch(pipeline, url)))
+                .flatMapCompletable(url -> FrescoObservables.prefetch(pipeline, url)
+                    .doOnError(error -> logger.error(error, "Problem Fetching Image"))
+                    .onErrorComplete()))
             .observeOn(AndroidSchedulers.mainThread());
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,12 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.google.gms:google-services:3.0.0'
-        classpath 'me.tatarka:gradle-retrolambda:3.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven { url 'https://jitpack.io' }
         maven {url "https://clojars.org/repo/"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip


### PR DESCRIPTION
Updates Gradle to 4.5 to hopefully fix Java 9 build errors on Windows.
Also fix an image loading bug that was happening since 2017's Guest images disappeared.
